### PR TITLE
Implement RFC 0050: Rename Buildpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # `gcr.io/paketo-buildpacks/jattach`
 
-The Paketo JAttach Buildpack is a Cloud Native Buildpack that provides the [JAttach binary](https://github.com/apangin/jattach) to send commands to a remote JVM via Dynamic Attach mechanism.
+The Paketo Buildpack for JAttach is a Cloud Native Buildpack that provides the [JAttach binary](https://github.com/apangin/jattach) to send commands to a remote JVM via Dynamic Attach mechanism.
 
 ## Behavior
 

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -19,7 +19,7 @@ api = "0.7"
   homepage = "https://github.com/paketo-buildpacks/jattach"
   id = "paketo-buildpacks/jattach"
   keywords = ["jattach", "java"]
-  name = "Paketo JAttach Buildpack"
+  name = "Paketo Buildpack for JAttach"
   sbom-formats = ["application/vnd.syft+json", "application/vnd.cyclonedx+json"]
   version = "{{.version}}"
 


### PR DESCRIPTION
Renames 'Paketo JAttach Buildpack' to 'Paketo Buildpack for JAttach'.

Implements RFC 0050, https://github.com/paketo-buildpacks/rfcs/issues/233, for this buildpack.

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>
